### PR TITLE
Refine action decision UI and risk scoring

### DIFF
--- a/src/components/ActionHUDPanel.tsx
+++ b/src/components/ActionHUDPanel.tsx
@@ -10,6 +10,7 @@ interface ActionHUDPanelProps {
   forecastData: ForecastResponse | null;
   loading?: boolean;
   onFeedback?: () => void;
+  className?: string;
 }
 
 const riskCopy: Record<string, string> = {
@@ -24,12 +25,16 @@ const ActionHUDPanel: React.FC<ActionHUDPanelProps> = ({
   forecastData,
   loading = false,
   onFeedback,
+  className,
 }) => {
   const { suggestions, dominantRisk } = useActionHUD({ aqiData, forecastData });
 
+  const baseClass = 'bg-white/95 backdrop-blur-md rounded-3xl shadow-xl p-6 w-full max-w-3xl';
+  const combinedClass = className ? `${baseClass} ${className}` : baseClass;
+
   if (loading) {
     return (
-      <div className="bg-white/95 backdrop-blur-md rounded-3xl shadow-xl p-6 w-full max-w-3xl animate-pulse">
+      <div className={`${combinedClass} animate-pulse`}>
         <div className="h-6 bg-gray-200 w-48 rounded mb-4" />
         <div className="space-y-3">
           {[1, 2, 3].map((item) => (
@@ -42,14 +47,14 @@ const ActionHUDPanel: React.FC<ActionHUDPanelProps> = ({
 
   if (!aqiData) {
     return (
-      <div className="bg-white rounded-3xl shadow-xl p-6 text-gray-500 w-full max-w-3xl">
+      <div className={`${combinedClass} text-gray-500`}>
         尚未取得空氣品質資料。
       </div>
     );
   }
 
   return (
-    <div className="bg-white/95 backdrop-blur-md rounded-3xl shadow-xl p-6 w-full max-w-3xl">
+    <div className={combinedClass}>
       <div className="flex flex-col gap-4">
         <header className="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
           <div>

--- a/src/components/PollutantFingerprintPanel.tsx
+++ b/src/components/PollutantFingerprintPanel.tsx
@@ -13,10 +13,10 @@ const POLLUTANT_CONFIG: Record<
     units: string;
   }
 > = {
-  pm25: { label: 'PM2.5', color: '#ef4444', max: 150, units: 'µg/m³' },
-  pm10: { label: 'PM10', color: '#f97316', max: 200, units: 'µg/m³' },
-  o3: { label: 'O₃', color: '#38bdf8', max: 180, units: 'ppb' },
-  no2: { label: 'NO₂', color: '#6366f1', max: 150, units: 'ppb' },
+  pm25: { label: 'PM2.5', color: '#14b8a6', max: 150, units: 'µg/m³' },
+  pm10: { label: 'PM10', color: '#f59e0b', max: 200, units: 'µg/m³' },
+  o3: { label: 'O₃', color: '#6366f1', max: 180, units: 'ppb' },
+  no2: { label: 'NO₂', color: '#ec4899', max: 150, units: 'ppb' },
   so2: { label: 'SO₂', color: '#22c55e', max: 75, units: 'ppb' },
 };
 

--- a/src/components/RiskMatrixPanel.tsx
+++ b/src/components/RiskMatrixPanel.tsx
@@ -17,6 +17,7 @@ interface RiskMatrixPanelProps {
     }>;
   } | null;
   loading?: boolean;
+  className?: string;
 }
 
 /**
@@ -26,6 +27,7 @@ const RiskMatrixPanel: React.FC<RiskMatrixPanelProps> = ({
   aqiData,
   forecastData,
   loading = false,
+  className,
 }) => {
   // 計算所有活動的風險決策
   const decisions = useMemo(() => {
@@ -42,9 +44,12 @@ const RiskMatrixPanel: React.FC<RiskMatrixPanelProps> = ({
     );
   }, [aqiData, forecastData]);
 
+  const baseClass = 'bg-white rounded-2xl shadow-xl p-6 max-w-4xl w-full';
+  const combinedClass = className ? `${baseClass} ${className}` : baseClass;
+
   if (loading) {
     return (
-      <div className="bg-white rounded-2xl shadow-xl p-6 animate-pulse">
+      <div className={`${combinedClass} animate-pulse`}>
         <div className="h-8 bg-gray-200 rounded w-1/2 mb-4"></div>
         <div className="space-y-3">
           {[1, 2, 3].map((i) => (
@@ -57,7 +62,7 @@ const RiskMatrixPanel: React.FC<RiskMatrixPanelProps> = ({
 
   if (!aqiData) {
     return (
-      <div className="bg-white rounded-2xl shadow-xl p-6">
+      <div className={`${combinedClass} text-gray-500`}>
         <h3 className="text-lg font-bold text-gray-800 mb-2">活動決策系統</h3>
         <p className="text-gray-500 text-sm">等待空氣品質數據...</p>
       </div>
@@ -65,7 +70,7 @@ const RiskMatrixPanel: React.FC<RiskMatrixPanelProps> = ({
   }
 
   return (
-    <div className="bg-white rounded-2xl shadow-xl p-6 max-w-4xl w-full">
+    <div className={combinedClass}>
       {/* 標題 */}
       <div className="mb-6">
         <h3 className="text-2xl font-bold text-gray-800 mb-2">


### PR DESCRIPTION
## Summary
- clarify the commute-zone legend and reorganize the bottom control bar to prevent overflow on smaller widths
- consolidate the action HUD and activity decision matrix into a shared modal with scrollable content and consistent styling
- tune the decision engine weighting and pollutant fingerprint palette so good-air scenarios are not flagged as cautionary

## Testing
- npm run test *(fails: vitest binary missing in environment)*
- npm run build *(fails: Next.js cannot download Google Fonts in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e140ad25c88323b8f8cb71dfd0e847